### PR TITLE
Make password input secure

### DIFF
--- a/wifi.sh
+++ b/wifi.sh
@@ -15,6 +15,6 @@ nmcli device wifi list
 echo WIFI NAME
 read wifi_name
 echo WIFI password
-read wifi_pass
+read -s wifi_pass
 nmcli device wifi connect $wifi_name password $wifi_pass 
 


### PR DESCRIPTION
Adding the `-s` flag for the `read` command turns the input prompt into a password prompt, which is relatively safer. 